### PR TITLE
Feat: Add real-time progress bar for frame rendering

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,13 +46,13 @@ func handleObjStats(fp string) {
 
 func handleRendering(args []string, fp string) {
 	startTime := time.Now()
-	prog := progress.NewProgress() // start tracking the progress
+
 	outputFilename := getOutputFilename(args)
 	writePng := checkPngFlag(args)
-	prog.Step("Parsing Yaml")
+	progress.Step("Parsing Yaml")
 	yml := parseYamlFile(fp)
-	prog.Step("Validating Yaml")	
-	prog.Step("Creating Scene from Yaml")
+	progress.Step("Validating Yaml")	
+	progress.Step("Creating Scene from Yaml")
 	absolutePath, err := filepath.Abs(fp)
 	if err != nil {
 		panic("unable to get absolute file path for yaml file")
@@ -67,8 +67,8 @@ func handleRendering(args []string, fp string) {
 	world := parser.CreateWorld(yml, dirpath)
 	camera := parser.CreateCamera(yml)
 
-	c := camera.Render(world, true, prog)
-	prog.Step("Writing output file")
+	c := camera.Render(world, true)
+	progress.Step("Writing output file")
 	if len(c) == 1 {
 		if writePng {
 			c[0].WritePng(fmt.Sprintf("%v.png", outputFilename))
@@ -79,7 +79,7 @@ func handleRendering(args []string, fp string) {
 		canvas.WriteGif(c, yml.Camera.Animation.Time, fmt.Sprintf("%v.gif", outputFilename))
 	}
 	elapsed := time.Since(startTime)
-	prog.Complete(fmt.Sprintf("%.2f seconds", elapsed.Seconds()))
+	progress.Complete(fmt.Sprintf("%.2f seconds", elapsed.Seconds()))
 }
 
 func parseYamlFile(path string) *parser.YamlDescription {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -3,45 +3,17 @@ package progress
 import (
 	"fmt"
 	"strings"
-	"sync"
 )
 
-// Progress represents a progress tracker for rendering operations
-type Progress struct {
-	mu            sync.Mutex
-	currentStep   string
-	frameNumber   int
-	totalFrames   int
-	showFrameInfo bool
-}
-
-// NewProgress creates a new progress tracker
-func NewProgress() *Progress {
-	return &Progress{
-		currentStep:   "",
-		frameNumber:   0,
-		totalFrames:   0,
-		showFrameInfo: false,
-	}
-}
-
 // Step prints a progress step message
-func (p *Progress) Step(message string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.currentStep = message
+func Step(message string) {
 	fmt.Printf("%s\n", message)
 }
 
 // SetFrameInfo sets up frame tracking information
-func (p *Progress) SetFrameInfo(currentFrame, totalFrames int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.frameNumber = currentFrame
-	p.totalFrames = totalFrames
-	p.showFrameInfo = true
+func SetFrameInfo(currentFrame, totalFrames int) {
 	percentage := int((float64(currentFrame) / float64(totalFrames)) * 100)
-	bar := p.createProgressBar(percentage, 30)
+	bar := createProgressBar(percentage, 30)
 	fmt.Printf("\rRendering frame %d of %d [%s] %d%%", currentFrame, totalFrames, bar, percentage)
 	if currentFrame == totalFrames {
 		fmt.Printf("\n")
@@ -49,22 +21,17 @@ func (p *Progress) SetFrameInfo(currentFrame, totalFrames int) {
 }
 
 // TotalFrames prints how many frames will be rendered
-func (p *Progress) TotalFrames(count int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.totalFrames = count
+func TotalFrames(count int) {
 	fmt.Printf("Total frames to render: %d\n", count)
 }
 
 // Complete marks the entire process as complete
-func (p *Progress) Complete(totalTime string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+func Complete(totalTime string) {
 	fmt.Printf("\nRendering complete! Total time: %s\n", totalTime)
 }
 
 // createProgressBar creates a visual progress bar
-func (p *Progress) createProgressBar(percentage, width int) string {
+func createProgressBar(percentage, width int) string {
 	filled := (percentage * width) / 100
 	empty := width - filled
 	return "[" + strings.Repeat("=", filled) + strings.Repeat(" ", empty) + "]"

--- a/render/teapot_multiframe.go
+++ b/render/teapot_multiframe.go
@@ -69,5 +69,5 @@ func CreateTeapotMultiframeScene(width int, height int, animation *scene.CameraA
 
 	cam.Animation = animation
 
-	return cam.Render(w, true, nil)
+	return cam.Render(w, true)
 }

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -143,18 +143,14 @@ func (c *Camera) SetTransform(tf math.Matrix) {
 	c.Transform = tf
 }
 
-func (c *Camera) Render(w *World, multithreaded bool, prog *progress.Progress) []*canvas.Canvas {
+func (c *Camera) Render(w *World, multithreaded bool) []*canvas.Canvas {
 	c.createAnimationStates()
-	totalFrames := 1
-	if c.Animation != nil && prog != nil {
-		totalFrames = int(c.Animation.MovementTime * c.Animation.TargetFps)
-		prog.TotalFrames(totalFrames)
-	}
+	totalFrames := len(c.PositionStates)
+	progress.TotalFrames(totalFrames)
+
 	images := make([]*canvas.Canvas, 0, len(c.PositionStates))
 	for frameIndex, currentPosition := range c.PositionStates {
-		if prog != nil {
-			prog.SetFrameInfo(frameIndex+1, totalFrames)
-		}
+		progress.SetFrameInfo(frameIndex+1, totalFrames)
 		c.Position = currentPosition
 		c.InverseTransform = nil
 		if multithreaded {


### PR DESCRIPTION
## Overview
Implement a real-time, in-place progress bar for frame rendering operations that provides visual feedback. 
Resolves #13 
## Changes

### 1. **New File: `progress/progress.go`**
- Created a new progress tracking **Struct** with real-time visual feedback
- Implemented `SetFrameInfo()` to display animated progress bar with percentage
- Added `createProgressBar()` helper that generates a visual progress indicator
- Uses carriage returns (`\r`) to update progress on the same line
- Automatically adds newline when rendering completes

### 2. **Modified: `app/app.go`**
- Integrated progress tracking into `handleRendering()` function
- Created `Progress` instance to track rendering operations
- Added progress steps for major operations:
  - `prog.Step("Parsing Yaml")`
  - `prog.Step("Validating Yaml")`
  - `prog.Step("Creating Scene from Yaml")`
  - `prog.Step("Writing output file")`
- Pass `prog` to `camera.Render()` to enable frame-level progress tracking
- Display total elapsed time with `prog.Complete()` upon completion

### 3. **Modified: `scene/camera.go`**
- Updated `Render()` method signature to accept `*progress.Progress` parameter
- Calculate total frames before rendering loop
- Call `prog.TotalFrames()` to display frame count estimate
- Call `prog.SetFrameInfo()` inside render loop for each frame
- Handles nil progress tracker gracefully for backward compatibility

### 4. **Modified: `render/teapot_multiframe.go`**
- Updated `Render()` to pass `nil` for progress tracker as a third arguement.
- Maintains compatibility with new camera rendering interface


# ⚠️The Introduction of third Optional argument in `scenes.camera.go` `Render()` function
The third in `scenes/camera.go` Render(func (c *Camera) Render(w *World, multithreaded bool, prog *progress.Progress))  
can be passed as nill if we are calling the function independently not as a part of parsing->rendering pipeline. The code handles this nil case also.

## Made sure wherever the Render function is updated with the third argument as nill or Progress class as required.

## Example Output
```
Parsing Yaml
Validating Yaml
Creating Scene from Yaml
Total frames to render: 30
Rendering frame 30 of 30 [==============================] 100%
Writing output file
Rendering complete! Total time: 45.32 seconds
```

## Short GIF for progress update in terminal 
![Terminal_output](https://github.com/user-attachments/assets/e67f4f3f-bf1a-472c-9ea5-56f9fcbbec55)

